### PR TITLE
Change CircleCI base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM circleci/golang:1.17
+FROM cimg/go:1.20.2
 
 RUN curl -L https://convox.com/cli/linux/convox -o /tmp/convox && \
       sudo mv /tmp/convox /usr/local/bin/convox && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM circleci/golang:1.12
+FROM circleci/golang:1.17
 
 RUN curl -L https://convox.com/cli/linux/convox -o /tmp/convox && \
       sudo mv /tmp/convox /usr/local/bin/convox && \


### PR DESCRIPTION
Slack is having a problem with outdated certs, bumping the image seems to be solving it.

https://status.slack.com/2023-03/9011b8a984a74042

However, since the image is deprecated, changing the base image will solve the issue.